### PR TITLE
fix projectMembers.delete not including type

### DIFF
--- a/src/services/projectMembers/ProjectMembers.ts
+++ b/src/services/projectMembers/ProjectMembers.ts
@@ -87,7 +87,7 @@ export class ProjectMembersService extends BaseService {
    * @summary Retrieve
 
    * @param project Project slug
-   * @param type_ Needed input variable
+   * @param type Needed input variable
    * @param slug Member's slug
    * @returns {Promise<ProjectMembersGetResponse>} - The promise with the result
    */
@@ -103,7 +103,7 @@ export class ProjectMembersService extends BaseService {
     }
     let urlEndpoint = '/v3/projects/project/members/member/{type}/{slug}';
     urlEndpoint = urlEndpoint.replace(
-      '{type_}',
+      '{type}',
       encodeURIComponent(serializePath('simple', false, type, undefined)),
     );
     urlEndpoint = urlEndpoint.replace(
@@ -126,7 +126,7 @@ export class ProjectMembersService extends BaseService {
   /**
    * @summary Update
 
-   * @param type_ Needed input variable
+   * @param type Needed input variable
    * @param slug Member's slug
    * @param project Project slug
    * @returns {Promise<ProjectMembersUpdateResponse>} - The promise with the result
@@ -146,7 +146,7 @@ export class ProjectMembersService extends BaseService {
     const headers: { [key: string]: string } = { 'Content-type': 'application/json' };
     let urlEndpoint = '/v3/projects/project/members/member/{type}/{slug}';
     urlEndpoint = urlEndpoint.replace(
-      '{type_}',
+      '{type}',
       encodeURIComponent(serializePath('simple', false, type, undefined)),
     );
     urlEndpoint = urlEndpoint.replace(
@@ -173,7 +173,7 @@ export class ProjectMembersService extends BaseService {
   /**
    * @summary Delete
 
-   * @param type_ Needed input variable
+   * @param type Needed input variable
    * @param slug Member's slug
    * @param project Project slug
    * @returns {Promise<any>} - The promise with the result

--- a/src/services/projectMembers/ProjectMembers.ts
+++ b/src/services/projectMembers/ProjectMembers.ts
@@ -187,9 +187,10 @@ export class ProjectMembersService extends BaseService {
     const queryParams: string[] = [];
     let urlEndpoint = '/v3/projects/project/members/member/{type}/{slug}';
     urlEndpoint = urlEndpoint.replace(
-      '{type_}',
+      '{type}',
       encodeURIComponent(serializePath('simple', false, type, undefined)),
     );
+
     urlEndpoint = urlEndpoint.replace(
       '{slug}',
       encodeURIComponent(serializePath('simple', false, slug, undefined)),

--- a/test/services/projectMembers/ProjectMembers.test.ts
+++ b/test/services/projectMembers/ProjectMembers.test.ts
@@ -99,7 +99,7 @@ describe('test ProjectMembers', () => {
   describe('test delete', () => {
     test('test api call', () => {
       const scope = nock('https://api.doppler.com')
-        .delete('/v3/projects/project/members/member/%7Btype%7D/quam?project=sunt')
+        .delete('/v3/projects/project/members/member/est/quam?project=sunt')
         .reply(200, { data: {} });
       return sdk.projectMembers
         .delete('est', 'quam', 'sunt')
@@ -115,7 +115,7 @@ describe('test ProjectMembers', () => {
 
     test('test will throw error on a non-200 response', () => {
       const scope = nock('https://api.doppler.com')
-        .delete('/v3/projects/project/members/member/%7Btype%7D/incidunt?project=quidem')
+        .delete('/v3/projects/project/members/member/repellat/incidunt?project=quidem')
         .reply(404, { data: {} });
       return expect(
         async () => await sdk.projectMembers.delete('repellat', 'incidunt', 'quidem'),

--- a/test/services/projectMembers/ProjectMembers.test.ts
+++ b/test/services/projectMembers/ProjectMembers.test.ts
@@ -72,7 +72,7 @@ describe('test ProjectMembers', () => {
   describe('test get', () => {
     test('test api call', () => {
       const scope = nock('https://api.doppler.com')
-        .get('/v3/projects/project/members/member/%7Btype%7D/officia?project=eligendi')
+        .get('/v3/projects/project/members/member/molestias/officia?project=eligendi')
         .reply(200, { data: {} });
       return sdk.projectMembers
         .get('eligendi', 'molestias', 'officia')
@@ -88,7 +88,7 @@ describe('test ProjectMembers', () => {
 
     test('test will throw error on a non-200 response', () => {
       const scope = nock('https://api.doppler.com')
-        .get('/v3/projects/project/members/member/%7Btype%7D/eaque?project=cumque')
+        .get('/v3/projects/project/members/member/esse/eaque?project=cumque')
         .reply(404, { data: {} });
       return expect(
         async () => await sdk.projectMembers.get('cumque', 'esse', 'eaque'),
@@ -126,7 +126,7 @@ describe('test ProjectMembers', () => {
   describe('test update', () => {
     test('test api call', () => {
       const scope = nock('https://api.doppler.com')
-        .patch('/v3/projects/project/members/member/%7Btype%7D/molestias?project=magni')
+        .patch('/v3/projects/project/members/member/at/molestias?project=magni')
         .reply(200, { data: {} });
       return sdk.projectMembers
         .update({}, 'at', 'molestias', 'magni')
@@ -142,7 +142,7 @@ describe('test ProjectMembers', () => {
 
     test('test will throw error on a non-200 response', () => {
       const scope = nock('https://api.doppler.com')
-        .patch('/v3/projects/project/members/member/%7Btype%7D/esse?project=harum')
+        .patch('/v3/projects/project/members/member/pariatur/esse?project=harum')
         .reply(404, { data: {} });
       return expect(
         async () => await sdk.projectMembers.update({}, 'pariatur', 'esse', 'harum'),


### PR DESCRIPTION
Fixes `('type' must be one of [workplace_user,group,invite,service_account].)` error on `projectMembers.delete`

### Issue

Was previously looking for `{type_}` with underscore, where the URL endpoint has `{type}`.

### Notable things

- Also updated methods `projectMembers.get` & `projectMembers.update`